### PR TITLE
J of Info Policy Revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # CHANGELOG
-## Second Draft, Submitted Nov. 24, 2020
+## _Journal of Information Policy_
+### Second Draft, Submitted Mar. 19, 2021, Accepted on Jul. 27, 2021
+- Expand the panel of FCC Form 477 data to include **all Census blocks** in the 48 contiguous states and Washington, DC.
+- Extend the panel to include Form 477 data from June 2019 and December 2019. Controls sourced from 2019 ACS also added.
+- Modified OLS estimators to include all competition count binaries, rather than using a “three or more” binary. 
+	- For cable specifications, the competition count binaries are as follows:
+		- Gigabit fiber: 1, 2, 3, 4
+		- Non-gigabit fiber: 1, 2, 3, 4, 5
+		- Cable: 2, 3, 4, 5
+		- aDSL: 1, 2, 3, 4
+	- For our aDSL download speed specifications, the competition count binaries are as follows:
+		- Gigabit fiber: 1, 2, 3, 4
+		- Non-gigabit fiber: 1, 2, 3, 4, 5
+		- Cable: 1, 2, 3, 4, 5
+		- aDSL: 2, 3, 4
+
+### First Draft, Submitted Nov. 29, 2020
+We submitted version identical to the second draft of the Center for Growth and Opportunity working paper for review.
+
+## Center for Growth and Opportunity Working Paper
+### Second Draft, Submitted Nov. 24, 2020
 - Cluster standard errors by Census tract 
 	- add `cluster(tractid)` after each `, robust` in `broadbandcompetition-panel.do`
 - Filter data to exclude reported broadband service that does not meet current FCC definition of broadband
@@ -23,7 +43,7 @@
 	- The shapefiles are available for the block groups for each state for each year in our panel. This allows us to calculate population density and housing density for each year according to the exact geographies for the year's in which they were estimated, rather than assuming that the 2010 Decennial Census closely approximated the geographies for the ACS. After reviewing a handful of states, year-to-year changes in the land area's reported in the TIGER/Line Shapefiles are actual common.
 	- Census discontinued American FactFinder website and the geography summary tables from which 2010 landareas. Accordingly, the landarea measures we use to calculate population density and housing density at the block group level could not be readily replicated without this update.
 
-## First Draft, Submitted Aug 28, 2019
+### First Draft, Submitted Aug. 28, 2019
 - Compile FCC Form 477 data from Dec 2014 through Dec 2017
 - Merge ACS and Census controls
 - Sample 20 percent of all US tracts due to computational limitations

--- a/README.md
+++ b/README.md
@@ -56,4 +56,8 @@ Collecting the data took considerable effort, and storing the source files and a
 
 I would love to hear from you if you publish any research that uses or was inspired by this repository! If you do so, please cite this repository and:
 
+Kotrous, Michael, and James Bailey. "Broadband Speeds in Fibered US Markets: An Empirical Analysis." Forthcoming. _Journal of Information Policy_.
+
+A [previous release](https://github.com/michaelkotrous/form477-panels/tree/v.1.0.1) of this repository can be used to replicate the dataset and results in the working paper version of this article, which can be cited as follows:
+
 Kotrous, Michael, and James Bailey. "Broadband Speeds in Fibered Markets: An Empirical Analysis." Working Paper, The Center for Growth and Opportunity at Utah State University, January 2021. [https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Form 477 Panels
-This project assembles a nine-part panel dataset of [Form 477](https://www.fcc.gov/general/broadband-deployment-data-fcc-form-477) broadband data from December 2014 through December 2018, sourced from the Federal Communications Commission. The Form 477 dataset reports fixed broadband service at the Census block level in the United States. The panel also includes demographic data for the years 2014 to 2018 from the U.S. Census Bureau, including:
+This project assembles an eleven-part panel dataset of [Form 477](https://www.fcc.gov/general/broadband-deployment-data-fcc-form-477) broadband data from December 2014 through December 2019, sourced from the Federal Communications Commission. The Form 477 dataset reports fixed broadband service at the Census block level in the United States. The panel also includes demographic data for the years 2014 to 2019 from the U.S. Census Bureau, including:
 
 - Population Density for U.S. block groups,
 - Housing Density for U.S. block groups, and
 - Median Income for U.S. tracts.
 
-You may use this repo to recreate the dataset used by and replicate the econometric results of [Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/).
+This version of the repo extends and expands the panel dataset used in the working paper versions of [Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/). A [previous release](https://github.com/michaelkotrous/form477-panels/tree/v1.0.0) of this repo can be used to recreate the dataset used by and replicate the econometric results of [Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/).
 
 ## License
 This project uses the MIT License, so you are free to copy and modify the code as it suits your research needs. The panel retains geographic identifiers for Census blocks, block groups, tracts, counties, and states, so joining additional demographic data should be fairly straightforward. I'm currently developing a project that joins [High-Cost Support data from USAC](https://opendata.usac.org/High-Cost/High-Cost-Connect-America-Fund-Broadband-Map-CAF-M/r59r-rpip) by Census block id, for example.
@@ -20,17 +20,17 @@ In the repo working directory, create two new directories: crosssection (note th
 
 **crosssection**: This directory is used to store each of the nine cross-sections of Form 477 data that has been joined with Census data. You are okay to leave this directory empty. It will be populated with files as the Stata scripts execute.
 
-**source**: This directory is used to store all source files (in csv format) from FCC, the U.S. Census Bureau, and U.S. Bureau of Labor Statistics. This directory must be populated with source files in order to work. You can download an archive ([.zip](https://form477-panels.s3.us-east-2.amazonaws.com/form477-panels.zip); [.tar.gz](https://form477-panels.s3.us-east-2.amazonaws.com/form477-panels.tar.gz)) of the source files used in [Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/). These files require just under 40 GB of storage. Note that when you extract the source files, the directory structure in your local environment (relative to the repo working directory) should look like `source/2014`, `source/2015`, and so on.
+**source**: This directory is used to store all source files (in csv format) from FCC, the U.S. Census Bureau, and U.S. Bureau of Labor Statistics. This directory must be populated with source files in order to work. You can download an archive ([.zip](); [.tar.gz]()) of the source files. These files require just under **40** GB of storage. Note that when you extract the source files, the directory structure in your local environment (relative to the repo working directory) should look like `source/2014`, `source/2015`, and so on.
 
-If you wish to see the final dataset or use it to run econometric tests, you can [download the final dataset](https://form477-panels.s3.us-east-2.amazonaws.com/US-Fixed-Panel-Random-Merged.dta) (~7 GB) used in [Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/). Keep in mind that this dataset only includes observations for 25 percent of U.S. Census tracts, which are randomly selected and include observations from all 48 contiguous states and Washington, D.C.
+If you wish to see the final dataset or use it to run econometric tests, you can [download the final dataset](https://form477-panels.s3.us-east-2.amazonaws.com/US-Fixed-Panel-Merged-1.1.x.dta) (~40 GB). This dataset includes observations for all U.S. Census tracts in the 48 contiguous states and Washington, D.C.
 
 ## Using the Scripts
 Executing the scripts is quite simple. Simply open `master.do` in Stata, define the working directory on line 7, and execute the do file. There's no need to edit or modify the do files in the scripts directory. The master do file will execute the supporting scripts in the appropriate order. 
 
 ## Changing the Sample, or Sample Size
-Assembling the full national panel for all U.S. Census tracts in the 48 contiguous U.S. states and Washington, D.C. requires at least 64 GB of RAM. The full national panel is over 32 GB in size.
+Assembling the full national panel for all U.S. Census tracts in the 48 contiguous U.S. states and Washington, D.C. requires at least 64 GB of RAM. The full national panel is about 40 GB in size.
 
-If you have insufficient RAM to work with the full national panel, you can select a sample by randomly drawing a given percentage of U.S. census tracts. Modify `master.do` to execute `append-random.do` rather than `append-full.do`. You will also need to edit line 10 of `scripts/broadbandcompetition-panel.do` to use the dataset US-Fixed-Panel-Random-Merged.dta.
+If you have insufficient RAM to work with the full national panel, you can select a sample by randomly drawing a given percentage of U.S. census tracts. Modify `master.do` to execute `append-random.do` rather than `append-full.do`. You will also need to edit lines 10,  of `scripts/broadbandcompetition-panel.do` to use the dataset US-Fixed-Panel-Random-Merged.dta.
 
 By default, `scripts/append-random.do` will sample 25 percent of U.S. census tracts. Edit line 36 of `scripts/append-random.do` to change the sample size. 
 
@@ -47,7 +47,9 @@ When the full `master.do` script is executed, four files will be placed in your 
 You will also notice that the `crosssection` directory is populated with Stata dta files for each merged cross-section of Form 477/ACS data, as well as various Stata log files with merger summaries and the like.
 
 ## Replicating Research
-Kotrous and Bailey (2020) analyzes a panel that samples 25 percent of U.S. Census tracts at random. The seed for replicating that sample is `5663451`. To draw a different sample of tracts, edit the seed on line 35 of `scripts/append-random.do`.
+[Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/) analyzes a panel for 2014 - 2018 that samples 25 percent of U.S. Census tracts at random. A [previous release](https://github.com/michaelkotrous/form477-panels/tree/v1.0.0) of this repo provides the version of code, and links to archives of the source files, used for that paper.
+
+The seed for replicating that sample is `5663451`. To draw a different sample of tracts, edit the seed on line 35 of `scripts/append-random.do`.
 
 ## Supporting the Project
 Collecting the data took considerable effort, and storing the source files and allowing you to retrieve them is not free. If you use or enjoy this repository, I would appreciate you [buying me a beer](https://paypal.me/michaelkotrous)! 🍺

--- a/README.md
+++ b/README.md
@@ -28,19 +28,26 @@ If you wish to see the final dataset or use it to run econometric tests, you can
 Executing the scripts is quite simple. Simply open `master.do` in Stata, define the working directory on line 7, and execute the do file. There's no need to edit or modify the do files in the scripts directory. The master do file will execute the supporting scripts in the appropriate order. 
 
 ## Changing the Sample, or Sample Size
-Due to insufficient RAM, Kotrous and Bailey (2020) analyzes a panel that samples 25 percent of U.S. Census tracts at random. The seed for replicating our sample is `5663451`. To draw a different sample of tracts, edit the seed on line 35 of `scripts/append-random.do`.
+Assembling the full national panel for all U.S. Census tracts in the 48 contiguous U.S. states and Washington, D.C. requires at least 64 GB of RAM. The full national panel is over 32 GB in size.
 
-To change the sample size to something other than 25 percent, edit line 36 of `scripts/append-random.do`. If you wish to work with the full panel (i.e., 100 percent of observations), instead modify `master.do` to execute `append-full.do`, rather than `append-random.do`. My guess is that you need at least 64 GB of RAM to load the full panel into Stata and execute the provided econometric tests.
+If you have insufficient RAM to work with the full national panel, you can select a sample by randomly drawing a given percentage of U.S. census tracts. Modify `master.do` to execute `append-random.do` rather than `append-full.do`. You will also need to edit line 10 of `scripts/broadbandcompetition-panel.do` to use the dataset US-Fixed-Panel-Random-Merged.dta.
+
+By default, `scripts/append-random.do` will sample 25 percent of U.S. census tracts. Edit line 36 of `scripts/append-random.do` to change the sample size. 
+
+You can define the seed to allow for replication of a sample on line 35 of `scripts/append-random.do`. The seed is set to `5663451`.
 
 ## Final Outputs
 When the full `master.do` script is executed, four files will be placed in your working directory.
 
-- US-Fixed-Panel-Random-Merged.dta (default, or US-Fixed-Panel-Merged.dta if `append-full.do` script is executed in master file instead of `append-random.do`)
+- US-Fixed-Panel-Merged.dta (default, or US-Fixed-Panel-Random-Merged.dta if `append-random.do` script is executed in master file instead of `append-full.do`)
 - broadbandcompetition-panel.log (Stata log with full econometric results)
 - regression-tables.rtf (Word-friendly format for regression tables)
 - regression-tables.tex (LaTeX file for regression tables)
 
 You will also notice that the `crosssection` directory is populated with Stata dta files for each merged cross-section of Form 477/ACS data, as well as various Stata log files with merger summaries and the like.
+
+## Replicating Research
+Kotrous and Bailey (2020) analyzes a panel that samples 25 percent of U.S. Census tracts at random. The seed for replicating that sample is `5663451`. To draw a different sample of tracts, edit the seed on line 35 of `scripts/append-random.do`.
 
 ## Supporting the Project
 Collecting the data took considerable effort, and storing the source files and allowing you to retrieve them is not free. If you use or enjoy this repository, I would appreciate you [buying me a beer](https://paypal.me/michaelkotrous)! 🍺

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In the repo working directory, create two new directories: crosssection (note th
 
 **crosssection**: This directory is used to store each of the nine cross-sections of Form 477 data that has been joined with Census data. You are okay to leave this directory empty. It will be populated with files as the Stata scripts execute.
 
-**source**: This directory is used to store all source files (in csv format) from FCC, the U.S. Census Bureau, and U.S. Bureau of Labor Statistics. This directory must be populated with source files in order to work. You can download an archive ([.zip](); [.tar.gz]()) of the source files. These files require just under **40** GB of storage. Note that when you extract the source files, the directory structure in your local environment (relative to the repo working directory) should look like `source/2014`, `source/2015`, and so on.
+**source**: This directory is used to store all source files (in csv format) from FCC, the U.S. Census Bureau, and U.S. Bureau of Labor Statistics. This directory must be populated with source files in order to work. You can download an archive ([.zip](https://form477-panels.s3.us-east-2.amazonaws.com/form477-panels-1.1.x.zip); [.tar.gz](https://form477-panels.s3.us-east-2.amazonaws.com/form477-panels-1.1.x.tar.gz)) of the source files. These files require just under 50 GB of storage. Note that when you extract the source files, the directory structure in your local environment (relative to the repo working directory) should look like `source/2014`, `source/2015`, and so on.
 
 If you wish to see the final dataset or use it to run econometric tests, you can [download the final dataset](https://form477-panels.s3.us-east-2.amazonaws.com/US-Fixed-Panel-Merged-1.1.x.dta) (~40 GB). This dataset includes observations for all U.S. Census tracts in the 48 contiguous states and Washington, D.C.
 
@@ -30,7 +30,7 @@ Executing the scripts is quite simple. Simply open `master.do` in Stata, define 
 ## Changing the Sample, or Sample Size
 Assembling the full national panel for all U.S. Census tracts in the 48 contiguous U.S. states and Washington, D.C. requires at least 64 GB of RAM. The full national panel is about 40 GB in size.
 
-If you have insufficient RAM to work with the full national panel, you can select a sample by randomly drawing a given percentage of U.S. census tracts. Modify `master.do` to execute `append-random.do` rather than `append-full.do`. You will also need to edit lines 10,  of `scripts/broadbandcompetition-panel.do` to use the dataset US-Fixed-Panel-Random-Merged.dta.
+If you have insufficient RAM to work with the full national panel, you can select a sample by randomly drawing a given percentage of U.S. census tracts. Modify `master.do` to execute `append-random.do` rather than `append-full.do`. You will also need to edit lines 10, 29, 47, 60, and 73 of `scripts/broadbandcompetition-panel.do` to use the dataset US-Fixed-Panel-Random-Merged.dta.
 
 By default, `scripts/append-random.do` will sample 25 percent of U.S. census tracts. Edit line 36 of `scripts/append-random.do` to change the sample size. 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project assembles an eleven-part panel dataset of [Form 477](https://www.fc
 - Housing Density for U.S. block groups, and
 - Median Income for U.S. tracts.
 
-This version of the repo extends and expands the panel dataset used in the working paper versions of [Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/). A [previous release](https://github.com/michaelkotrous/form477-panels/tree/v1.0.0) of this repo can be used to recreate the dataset used by and replicate the econometric results of [Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/).
+This version of the repo extends and expands the panel dataset used in the working paper versions of [Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/). A [previous release](https://github.com/michaelkotrous/form477-panels/tree/v.1.0.1) of this repo can be used to recreate the dataset used by and replicate the econometric results of [Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/).
 
 ## License
 This project uses the MIT License, so you are free to copy and modify the code as it suits your research needs. The panel retains geographic identifiers for Census blocks, block groups, tracts, counties, and states, so joining additional demographic data should be fairly straightforward. I'm currently developing a project that joins [High-Cost Support data from USAC](https://opendata.usac.org/High-Cost/High-Cost-Connect-America-Fund-Broadband-Map-CAF-M/r59r-rpip) by Census block id, for example.
@@ -47,7 +47,7 @@ When the full `master.do` script is executed, four files will be placed in your 
 You will also notice that the `crosssection` directory is populated with Stata dta files for each merged cross-section of Form 477/ACS data, as well as various Stata log files with merger summaries and the like.
 
 ## Replicating Research
-[Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/) analyzes a panel for 2014 - 2018 that samples 25 percent of U.S. Census tracts at random. A [previous release](https://github.com/michaelkotrous/form477-panels/tree/v1.0.0) of this repo provides the version of code, and links to archives of the source files, used for that paper.
+[Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/) analyzes a panel for 2014 - 2018 that samples 25 percent of U.S. Census tracts at random. A [previous release](https://github.com/michaelkotrous/form477-panels/tree/v.1.0.1) of this repo provides the version of code, and links to archives of the source files, used for that paper.
 
 The seed for replicating that sample is `5663451`. To draw a different sample of tracts, edit the seed on line 35 of `scripts/append-random.do`.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you have insufficient RAM to work with the full national panel, you can selec
 
 By default, `scripts/append-random.do` will sample 25 percent of U.S. census tracts. Edit line 36 of `scripts/append-random.do` to change the sample size. 
 
-You can define the seed to allow for replication of a sample on line 35 of `scripts/append-random.do`. The seed is set to `5663451`.
+You can define the seed to allow for replication of a sample on line 35 of `scripts/append-random.do`. The seed is set to `5663451`. You can [download a dataset](https://form477-panels.s3.us-east-2.amazonaws.com/US-Fixed-Panel-Random-Merged-1.1.x.dta) (~10 GB) that uses this seed to draw a sample of 25 percent of U.S. census tracts from Dec. 2014 to Dec. 2019.
 
 ## Final Outputs
 When the full `master.do` script is executed, four files will be placed in your working directory.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project assembles an eleven-part panel dataset of [Form 477](https://www.fc
 - Housing Density for U.S. block groups, and
 - Median Income for U.S. tracts.
 
-This version of the repo extends and expands the panel dataset used in the working paper versions of [Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/). A [previous release](https://github.com/michaelkotrous/form477-panels/tree/v.1.0.1) of this repo can be used to recreate the dataset used by and replicate the econometric results of [Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/).
+This repository can be used to replicate the dataset and econometric results of articles by Kotrous and Bailey (see [Replicating Research](#Replicating-Research) below).
 
 ## License
 This project uses the MIT License, so you are free to copy and modify the code as it suits your research needs. The panel retains geographic identifiers for Census blocks, block groups, tracts, counties, and states, so joining additional demographic data should be fairly straightforward. I'm currently developing a project that joins [High-Cost Support data from USAC](https://opendata.usac.org/High-Cost/High-Cost-Connect-America-Fund-Broadband-Map-CAF-M/r59r-rpip) by Census block id, for example.
@@ -47,9 +47,9 @@ When the full `master.do` script is executed, four files will be placed in your 
 You will also notice that the `crosssection` directory is populated with Stata dta files for each merged cross-section of Form 477/ACS data, as well as various Stata log files with merger summaries and the like.
 
 ## Replicating Research
-[Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/) analyzes a panel for 2014 - 2018 that samples 25 percent of U.S. Census tracts at random. A [previous release](https://github.com/michaelkotrous/form477-panels/tree/v.1.0.1) of this repo provides the version of code, and links to archives of the source files, used for that paper.
+The 1.1.0 release of this repository can be used to replicate the dataset and econometric results of a forthcoming article by Kotrous and Bailey in the _Journal of Information Policy_.
 
-The seed for replicating that sample is `5663451`. To draw a different sample of tracts, edit the seed on line 35 of `scripts/append-random.do`.
+The [1.0.1 release](https://github.com/michaelkotrous/form477-panels/tree/v.1.0.1) can be used to replicate [Kotrous and Bailey (2021)](https://www.thecgo.org/research/broadband-speeds-in-fibered-markets-an-empirical-analysis/), a working paper released by the Center for Growth and Opportunity in Jan. 2021. That working paper analyzes a panel for 2014 - 2018 that samples 25 percent of U.S. Census tracts at random. The seed for replicating that sample is `5663451`. To draw a different sample of tracts, edit the seed on line 35 of `scripts/append-random.do`.
 
 ## Supporting the Project
 Collecting the data took considerable effort, and storing the source files and allowing you to retrieve them is not free. If you use or enjoy this repository, I would appreciate you [buying me a beer](https://paypal.me/michaelkotrous)! 🍺

--- a/master.do
+++ b/master.do
@@ -12,7 +12,7 @@ global states AL AZ AR CA CO CT DE DC FL GA ID IL IN IA KS KY LA ME MD MA MI MN 
 /* Produce dta files to be used for mergers in annual dataset files */
 do scripts/shared-data
 
-/* Assemble cross-sections for years 2014-2017 */
+/* Assemble cross-sections for years 2014-2018 */
 do scripts/crosssection-201412
 do scripts/crosssection-201506
 do scripts/crosssection-201512

--- a/master.do
+++ b/master.do
@@ -1,6 +1,6 @@
 /* -------------------
  ** FCC FORM 477 PANEL
- ** UNITED STATES, 2014-2018
+ ** UNITED STATES, 2014-2019
  * ------------------- */
 
 set more off
@@ -22,6 +22,8 @@ do scripts/crosssection-201706
 do scripts/crosssection-201712
 do scripts/crosssection-201806
 do scripts/crosssection-201812
+do scripts/crosssection-201906
+do scripts/crosssection-201912
 
 /* Append cross-sections to make full panel */
 //do scripts/append-random

--- a/master.do
+++ b/master.do
@@ -24,8 +24,8 @@ do scripts/crosssection-201806
 do scripts/crosssection-201812
 
 /* Append cross-sections to make full panel */
-do scripts/append-random
-//do scripts/append-full
+//do scripts/append-random
+do scripts/append-full
 
 /* Run econometric tests */
 do scripts/broadbandcompetition-panel

--- a/scripts/append-full.do
+++ b/scripts/append-full.do
@@ -10,5 +10,9 @@ append using crosssection/US-Fixed-Merged-201506 crosssection/US-Fixed-Merged-20
 /* FORMAT DATASET BY SORTING, ORDERING, AND LABELING */
 do scripts/helpers/dataset-formatting
 
+
+/* DESCRIBE DATASET */
+label data "FCC Form 477 Fixed Broadband Data, 2014-2018"
+
 save US-Fixed-Panel-Merged, replace
 clear

--- a/scripts/append-full.do
+++ b/scripts/append-full.do
@@ -4,7 +4,7 @@
 ** - US-Fixed-Panel-Merged.dta */
 
 use crosssection/US-Fixed-Merged-201412, clear
-append using crosssection/US-Fixed-Merged-201506 crosssection/US-Fixed-Merged-201512 crosssection/US-Fixed-Merged-201606 crosssection/US-Fixed-Merged-201612 crosssection/US-Fixed-Merged-201706 crosssection/US-Fixed-Merged-201712 crosssection/US-Fixed-Merged-201806 crosssection/US-Fixed-Merged-201812
+append using crosssection/US-Fixed-Merged-201506 crosssection/US-Fixed-Merged-201512 crosssection/US-Fixed-Merged-201606 crosssection/US-Fixed-Merged-201612 crosssection/US-Fixed-Merged-201706 crosssection/US-Fixed-Merged-201712 crosssection/US-Fixed-Merged-201806 crosssection/US-Fixed-Merged-201812 crosssection/US-Fixed-Merged-201906 crosssection/US-Fixed-Merged-201912
 
 
 /* FORMAT DATASET BY SORTING, ORDERING, AND LABELING */
@@ -12,7 +12,7 @@ do scripts/helpers/dataset-formatting
 
 
 /* DESCRIBE DATASET */
-label data "FCC Form 477 Fixed Broadband Data, 2014-2018"
+label data "FCC Form 477 Fixed Broadband Data, 2014-2019"
 
 save US-Fixed-Panel-Merged, replace
 clear

--- a/scripts/append-random.do
+++ b/scripts/append-random.do
@@ -116,7 +116,7 @@ use crosssection/US-Fixed-Merged-201912, clear
 merge m:1 tractid using `tracts_fullControls', generate(_merge_sampleTracts)
 keep if _merge_sampleTracts == 3
 
-/* APPEND CROSS-SECTION SAMPLES TO DEC 2018 TO MAKE FULL PANEL */
+/* APPEND CROSS-SECTION SAMPLES TO DEC 2019 TO MAKE FULL PANEL */
 append using `sample_201412' `sample_201506' `sample_201512' `sample_201606' `sample_201612' `sample_201706' `sample_201712' `sample_201806' `sample_201812' `sample_201906'
 
 log close

--- a/scripts/append-random.do
+++ b/scripts/append-random.do
@@ -116,5 +116,9 @@ drop _merge_population _merge_housingunits _merge_landarea _merge_medianincome _
 /* FORMAT DATASET BY SORTING, ORDERING, AND LABELING */
 do scripts/helpers/dataset-formatting
 
+
+/* DESCRIBE DATASET */
+label data "FCC Form 477 Fixed Broadband Data, 2014-2018 from 25 percent of US Census Tracts"
+
 save US-Fixed-Panel-Random-Merged, replace
 clear

--- a/scripts/append-random.do
+++ b/scripts/append-random.do
@@ -7,7 +7,7 @@
 
 /* RANDOMLY SELECT ONE-FOURTH OF CLEAN TRACTS */
 // Identify tracts with ACS control variables that failed to merge (population, housing, or income) with 477 cross-sections
-// Note: Tracts that failed to merge with 477 data were identical in 2015, 2016, 2017, and 2018. All tracts that failed to merge in 2014 also failed in the other years, but three tracts that failed to merge in later years succeeded in 2014. 
+// Note: Tracts that failed to merge with 477 data were identical in 2015, 2016, 2017, 2018, and 2019. All tracts that failed to merge in 2014 also failed in the other years, but three tracts that failed to merge in later years succeeded in 2014. 
 tempfile tracts_missingControls
 use crosssection/US-Fixed-Merged-201812, clear
 collapse (count) logrecno if _merge_population == 1 | _merge_housingunits == 1 | _merge_medianincome == 1, by(tractid)
@@ -98,13 +98,26 @@ keep if _merge_sampleTracts == 3
 save `sample_201806'
 
 // Dec 2018
+tempfile sample_201812
 use crosssection/US-Fixed-Merged-201812, clear
 merge m:1 tractid using `tracts_fullControls', generate(_merge_sampleTracts)
 keep if _merge_sampleTracts == 3
+save `sample_201812'
 
+// Jun 2019
+tempfile sample_201906
+use crosssection/US-Fixed-Merged-201906, clear
+merge m:1 tractid using `tracts_fullControls', generate(_merge_sampleTracts)
+keep if _merge_sampleTracts == 3
+save `sample_201906'
+
+// Dec 2019
+use crosssection/US-Fixed-Merged-201912, clear
+merge m:1 tractid using `tracts_fullControls', generate(_merge_sampleTracts)
+keep if _merge_sampleTracts == 3
 
 /* APPEND CROSS-SECTION SAMPLES TO DEC 2018 TO MAKE FULL PANEL */
-append using `sample_201412' `sample_201506' `sample_201512' `sample_201606' `sample_201612' `sample_201706' `sample_201712' `sample_201806'
+append using `sample_201412' `sample_201506' `sample_201512' `sample_201606' `sample_201612' `sample_201706' `sample_201712' `sample_201806' `sample_201812' `sample_201906'
 
 log close
 
@@ -118,7 +131,7 @@ do scripts/helpers/dataset-formatting
 
 
 /* DESCRIBE DATASET */
-label data "FCC Form 477 Fixed Broadband Data, 2014-2018 from 25 percent of US Census Tracts"
+label data "FCC Form 477 Fixed Broadband Data, 2014-2019 from 25 percent of US Census Tracts"
 
 save US-Fixed-Panel-Random-Merged, replace
 clear

--- a/scripts/broadbandcompetition-panel.do
+++ b/scripts/broadbandcompetition-panel.do
@@ -84,7 +84,7 @@ gen ln_maxaddown_kbps = ln(maxaddown_kbps)
 drop maxaddown_kbps
 
 // Take logs of income, housing and population density
-gen ln_medianincome_tract_2018 = ln(medianincome_tract_2018)
+gen ln_medianincome_tract_2019 = ln(medianincome_tract_2019)
 gen ln_housing_density = ln(housing_density)
 gen ln_popln_density = ln(popln_density)
 
@@ -94,7 +94,7 @@ gen ln_popln_density = ln(popln_density)
  * ------------------- */
 
 label variable ln_maxaddown_kbps "ln(Download Speed, kbps)"
-label variable ln_medianincome_tract_2018 "ln(Median Income)"
+label variable ln_medianincome_tract_2019 "ln(Median Income)"
 label variable ln_housing_density "ln(Housing Density)"
 label variable ln_popln_density "ln(Population Density)"
 
@@ -106,7 +106,7 @@ label variable ln_popln_density "ln(Population Density)"
 /* Describe dataset */
 describe
 labelbook
-codebook ln_maxaddown_kbps count_fiberGigabit count_fiberNonGigabit count_cable count_aDSL ln_medianincome_tract_2018 ln_housing_density ln_popln_density month stateabbr stateid countyid tractid blkgrpid blockid, header
+codebook ln_maxaddown_kbps count_fiberGigabit count_fiberNonGigabit count_cable count_aDSL ln_medianincome_tract_2019 ln_housing_density ln_popln_density month stateabbr stateid countyid tractid blkgrpid blockid, header
 
 /* Show values and count observations for tech and speeds */ 
 tab techcode
@@ -145,7 +145,7 @@ tab maxaddown count_fiberGigabit if techcode == 50
 tab maxaddown count_fiberNonGigabit if techcode == 50
 
 /* Summarize controls */
-sum medianincome_tract_2018 ln_medianincome_tract_2018
+sum medianincome_tract_2019 ln_medianincome_tract_2019
 sum housing_density popln_density ln_housing_density ln_popln_density
 
 
@@ -155,59 +155,59 @@ sum housing_density popln_density ln_housing_density ln_popln_density
 
 /* HOUSING DENSITY */
 // Simple OLS (est1)
-eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_housing_density if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "No", replace
 
 // State Fixed Effects (est2)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density i.stateabbr if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_housing_density i.stateabbr if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "No", replace
 
 // Time Fixed Effects (est3)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_housing_density i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "Yes", replace
 
 // State & Time Fixed Effects (est4)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density i.stateabbr i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_housing_density i.stateabbr i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "Yes", replace
 
-summarize ln_maxaddown_kbps ln_medianincome_tract_2018 ln_housing_density if e(sample)
+summarize ln_maxaddown_kbps ln_medianincome_tract_2019 ln_housing_density if e(sample)
 
 
 /* POPULATION DENSITY */
 // Simple OLS (est5)
-eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_popln_density if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "No", replace
 
 // State Fixed Effects (est6)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density i.stateabbr if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_popln_density i.stateabbr if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "No", replace
 
 // Time Fixed Effects (est7)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_popln_density i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "Yes", replace
 
 // State & Time Fixed Effects (est8)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density i.stateabbr i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_popln_density i.stateabbr i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "Yes", replace
 
-summarize ln_maxaddown_kbps ln_medianincome_tract_2018 ln_popln_density if e(sample)
+summarize ln_maxaddown_kbps ln_medianincome_tract_2019 ln_popln_density if e(sample)
 
 tab1 binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 if e(sample)
 
 
 /* TABLE: aDSL Service, Competition Count Specifications */
 // Export results of all aDSL regressions in RTF and Tex formats
-esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.rtf, title("Table: aDSL Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) replace
+esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.rtf, title("Table: aDSL Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) replace
 
-esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.tex, title("Table: aDSL Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) replace
+esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.tex, title("Table: aDSL Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) replace
 
 eststo clear
 
@@ -218,59 +218,59 @@ eststo clear
 
 /* HOUSING DENSITY */
 // Simple OLS (est1)
-eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_housing_density if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "No", replace
 
 // State Fixed Effects (est2)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density i.stateabbr if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_housing_density i.stateabbr if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "No", replace
 
 // Time Fixed Effects (est3)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_housing_density i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "Yes", replace
 
 // State & Time Fixed Effects (est4)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density i.stateabbr i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_housing_density i.stateabbr i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "Yes", replace
 
-summarize ln_maxaddown_kbps ln_medianincome_tract_2018 ln_housing_density if e(sample)
+summarize ln_maxaddown_kbps ln_medianincome_tract_2019 ln_housing_density if e(sample)
 
 
 /* POPULATION DENSITY */
 // Simple OLS (est5)
-eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_popln_density if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "No", replace
 
 // State Fixed Effects (est6)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density i.stateabbr if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_popln_density i.stateabbr if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "No", replace
 
 // Time Fixed Effects (est7)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_popln_density i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "Yes", replace
 
 // State & Time Fixed Effects (est8)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density i.stateabbr i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_popln_density i.stateabbr i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "Yes", replace
 
-summarize ln_maxaddown_kbps ln_medianincome_tract_2018 ln_popln_density if e(sample)
+summarize ln_maxaddown_kbps ln_medianincome_tract_2019 ln_popln_density if e(sample)
 
 tab1 binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 if e(sample)
 
 
 /* TABLE: Cable Service, Competition Count Specifications */
 // Export results of all cable regressions in RTF and Tex formats
-esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.rtf, title("Table: Cable Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
+esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.rtf, title("Table: Cable Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
 
-esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.tex, title("Table: Cable Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
+esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.tex, title("Table: Cable Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2019 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
 
 eststo clear
 
@@ -281,59 +281,59 @@ eststo clear
 
 /* HOUSING DENSITY */
 // Simple OLS (est1)
-eststo: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2018 ln_housing_density if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2019 ln_housing_density if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "No", replace
 
 // State Fixed Effects (est2)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2018 ln_housing_density i.stateabbr if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2019 ln_housing_density i.stateabbr if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "No", replace
 
 // Time Fixed Effects (est3)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2018 ln_housing_density i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2019 ln_housing_density i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "Yes", replace
 
 // State & Time Fixed Effects (est4)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2018 ln_housing_density i.stateabbr i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2019 ln_housing_density i.stateabbr i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "Yes", replace
 
-summarize ln_maxaddown_kbps ln_medianincome_tract_2018 ln_housing_density if e(sample)
+summarize ln_maxaddown_kbps ln_medianincome_tract_2019 ln_housing_density if e(sample)
 
 
 /* POPULATION DENSITY */
 // Simple OLS (est5)
-eststo: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2018 ln_popln_density if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2019 ln_popln_density if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "No", replace
 
 // State Fixed Effects (est6)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2018 ln_popln_density i.stateabbr if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2019 ln_popln_density i.stateabbr if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "No", replace
 
 // Time Fixed Effects (est7)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2018 ln_popln_density i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2019 ln_popln_density i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "Yes", replace
 
 // State & Time Fixed Effects (est8)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2018 ln_popln_density i.stateabbr i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2019 ln_popln_density i.stateabbr i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "Yes", replace
 
-summarize ln_maxaddown_kbps ln_medianincome_tract_2018 ln_popln_density if e(sample)
+summarize ln_maxaddown_kbps ln_medianincome_tract_2019 ln_popln_density if e(sample)
 
 tab1 binary_fiberGigabit binary_fiberNonGigabit binary_cable if e(sample)
 
 
 /* TABLE: aDSL Service, Competition Presence Specifications */
 // Export results of all aDSL regressions in RTF and Tex formats
-esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.rtf, title("Table: aDSL Service, Competition Presence Dummies") keep(binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
+esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.rtf, title("Table: aDSL Service, Competition Presence Dummies") keep(binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2019 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
 
-esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.tex, title("Table: aDSL Service, Competition Presence Dummies") keep(binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
+esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.tex, title("Table: aDSL Service, Competition Presence Dummies") keep(binary_fiberGigabit binary_fiberNonGigabit binary_cable ln_medianincome_tract_2019 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
 
 eststo clear
 
@@ -344,59 +344,59 @@ eststo clear
 
 /* HOUSING DENSITY */
 // Simple OLS (est1)
-eststo: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2018 ln_housing_density if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2019 ln_housing_density if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "No", replace
 
 // State Fixed Effects (est2)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2018 ln_housing_density i.stateabbr if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2019 ln_housing_density i.stateabbr if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "No", replace
 
 // Time Fixed Effects (est3)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2018 ln_housing_density i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2019 ln_housing_density i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "Yes", replace
 
 // State & Time Fixed Effects (est4)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2018 ln_housing_density i.stateabbr i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2019 ln_housing_density i.stateabbr i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "Yes", replace
 
-summarize ln_maxaddown_kbps ln_medianincome_tract_2018 ln_housing_density if e(sample)
+summarize ln_maxaddown_kbps ln_medianincome_tract_2019 ln_housing_density if e(sample)
 
 
 /* POPULATION DENSITY */
 // Simple OLS (est5)
-eststo: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2018 ln_popln_density if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2019 ln_popln_density if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "No", replace
 
 // State Fixed Effects (est6)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2018 ln_popln_density i.stateabbr if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2019 ln_popln_density i.stateabbr if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "No", replace
 
 // Time Fixed Effects (est7)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2018 ln_popln_density i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2019 ln_popln_density i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "Yes", replace
 
 // State & Time Fixed Effects (est8)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2018 ln_popln_density i.stateabbr i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2019 ln_popln_density i.stateabbr i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "Yes", replace
 
-summarize ln_maxaddown_kbps ln_medianincome_tract_2018 ln_popln_density if e(sample)
+summarize ln_maxaddown_kbps ln_medianincome_tract_2019 ln_popln_density if e(sample)
 
 tab1 binary_fiberGigabit binary_fiberNonGigabit binary_aDSL if e(sample)
 
 
 /* TABLE: Cable Service, Competition Presence Specifications */
 // Export results of all aDSL regressions in RTF and Tex formats
-esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.rtf, title("Table: Cable Service, Competition Presence Dummies") keep(binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
+esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.rtf, title("Table: Cable Service, Competition Presence Dummies") keep(binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2019 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
 
-esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.tex, title("Table: Cable Service, Competition Presence Dummies") keep(binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
+esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.tex, title("Table: Cable Service, Competition Presence Dummies") keep(binary_fiberGigabit binary_fiberNonGigabit binary_aDSL ln_medianincome_tract_2019 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
 
 eststo clear
 

--- a/scripts/broadbandcompetition-panel.do
+++ b/scripts/broadbandcompetition-panel.do
@@ -26,7 +26,7 @@ tab count_aDSL
 tab count_cable
 tab count_fiber
 
-use US-Fixed-Panel-Random-Merged, clear
+use US-Fixed-Panel-Merged, clear
 
 
 /* ------------------- 
@@ -44,7 +44,7 @@ collapse (max) count_cable count_fiber, by(blockid)
 tab count_cable
 tab count_fiber
 
-use US-Fixed-Panel-Random-Merged, clear
+use US-Fixed-Panel-Merged, clear
 
 // Cable, by year-month
 keep if inlist(techcode, 40, 41, 42, 43)
@@ -57,7 +57,7 @@ collapse (max) count_aDSL count_fiber, by(blockid)
 tab count_aDSL
 tab count_fiber
 
-use US-Fixed-Panel-Random-Merged, clear
+use US-Fixed-Panel-Merged, clear
 
 // Fiber, by year-month
 keep if techcode == 50
@@ -70,7 +70,7 @@ collapse (max) count_aDSL count_cable, by(blockid)
 tab count_aDSL
 tab count_cable
 
-use US-Fixed-Panel-Random-Merged, clear
+use US-Fixed-Panel-Merged, clear
 
 
 /* -------------------

--- a/scripts/broadbandcompetition-panel.do
+++ b/scripts/broadbandcompetition-panel.do
@@ -7,7 +7,7 @@
 
 log using broadbandcompetition-panel.log, replace
 
-use US-Fixed-Panel-Random-Merged, clear
+use US-Fixed-Panel-Merged, clear
 
 
 /* ------------------- 

--- a/scripts/broadbandcompetition-panel.do
+++ b/scripts/broadbandcompetition-panel.do
@@ -155,22 +155,22 @@ sum housing_density popln_density ln_housing_density ln_popln_density
 
 /* HOUSING DENSITY */
 // Simple OLS (est1)
-eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL2 binary_aDSL3 binary_cable1 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_housing_density if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "No", replace
 
 // State Fixed Effects (est2)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL2 binary_aDSL3 binary_cable1 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_housing_density i.stateabbr if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density i.stateabbr if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "No", replace
 
 // Time Fixed Effects (est3)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL2 binary_aDSL3 binary_cable1 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_housing_density i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "Yes", replace
 
 // State & Time Fixed Effects (est4)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL2 binary_aDSL3 binary_cable1 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_housing_density i.stateabbr i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density i.stateabbr i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "Yes", replace
 
@@ -179,35 +179,35 @@ summarize ln_maxaddown_kbps ln_medianincome_tract_2018 ln_housing_density if e(s
 
 /* POPULATION DENSITY */
 // Simple OLS (est5)
-eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL2 binary_aDSL3 binary_cable1 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_popln_density if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "No", replace
 
 // State Fixed Effects (est6)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL2 binary_aDSL3 binary_cable1 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_popln_density i.stateabbr if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density i.stateabbr if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "No", replace
 
 // Time Fixed Effects (est7)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL2 binary_aDSL3 binary_cable1 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_popln_density i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "Yes", replace
 
 // State & Time Fixed Effects (est8)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL2 binary_aDSL3 binary_cable1 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_popln_density i.stateabbr i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density i.stateabbr i.month if inlist(techcode, 10, 11, 12), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "Yes", replace
 
 summarize ln_maxaddown_kbps ln_medianincome_tract_2018 ln_popln_density if e(sample)
 
-tab1 binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL2 binary_aDSL3 binary_cable1 binary_cable2 binary_cable3 if e(sample)
+tab1 binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 if e(sample)
 
 
 /* TABLE: aDSL Service, Competition Count Specifications */
 // Export results of all aDSL regressions in RTF and Tex formats
-esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.rtf, title("Table: aDSL Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL2 binary_aDSL3 binary_cable1 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) replace
+esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.rtf, title("Table: aDSL Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) replace
 
-esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.tex, title("Table: aDSL Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL2 binary_aDSL3 binary_cable1 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) replace
+esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.tex, title("Table: aDSL Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) replace
 
 eststo clear
 
@@ -218,22 +218,22 @@ eststo clear
 
 /* HOUSING DENSITY */
 // Simple OLS (est1)
-eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_housing_density if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "No", replace
 
 // State Fixed Effects (est2)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_housing_density i.stateabbr if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density i.stateabbr if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "No", replace
 
 // Time Fixed Effects (est3)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_housing_density i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "Yes", replace
 
 // State & Time Fixed Effects (est4)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_housing_density i.stateabbr i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density i.stateabbr i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "Yes", replace
 
@@ -242,35 +242,35 @@ summarize ln_maxaddown_kbps ln_medianincome_tract_2018 ln_housing_density if e(s
 
 /* POPULATION DENSITY */
 // Simple OLS (est5)
-eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_popln_density if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "No", replace
 
 // State Fixed Effects (est6)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_popln_density i.stateabbr if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density i.stateabbr if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "No", replace
 
 // Time Fixed Effects (est7)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_popln_density i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "No", replace
 estadd local time_fe "Yes", replace
 
 // State & Time Fixed Effects (est8)
-eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_popln_density i.stateabbr i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
+eststo: xi: reg ln_maxaddown_kbps binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_popln_density i.stateabbr i.month if inlist(techcode, 40, 41, 42, 43), robust cluster(tractid)
 estadd local state_fe "Yes", replace
 estadd local time_fe "Yes", replace
 
 summarize ln_maxaddown_kbps ln_medianincome_tract_2018 ln_popln_density if e(sample)
 
-tab1 binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_cable2 binary_cable3 if e(sample)
+tab1 binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 if e(sample)
 
 
 /* TABLE: Cable Service, Competition Count Specifications */
 // Export results of all cable regressions in RTF and Tex formats
-esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.rtf, title("Table: Cable Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
+esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.rtf, title("Table: Cable Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
 
-esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.tex, title("Table: Cable Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_cable2 binary_cable3 ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
+esttab est1 est5 est2 est6 est3 est7 est4 est8 using regression-tables.tex, title("Table: Cable Service, Competition Count Dummies") keep(binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5 binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 binary_cable2 binary_cable3 binary_cable4 binary_cable5 ln_medianincome_tract_2018 ln_housing_density ln_popln_density _cons) label s(state_fe time_fe N, label("State Fixed Effects" "Time Fixed Effects" "N")) append
 
 eststo clear
 

--- a/scripts/crosssection-201906.do
+++ b/scripts/crosssection-201906.do
@@ -1,16 +1,16 @@
-/* Produce June 2018 dataset with
-** - ACS, block group landarea merged into June 2018 FCC Form 477 dataset,
+/* Produce June 2019 dataset with
+** - ACS, block group landarea merged into June 2019 FCC Form 477 dataset,
 ** - Housing and Population Density values, and
 ** - Competition metrics 
 **
 ** Outputs:
-** - crosssection/US-Fixed-Merged-201806.dta
-** - crosssection/merge-source-201806.log
-** - crosssection/merge-competition-vars-201806.log */
+** - crosssection/US-Fixed-Merged-201906.dta
+** - crosssection/merge-source-201906.log
+** - crosssection/merge-competition-vars-201906.log */
 
-global year 2018
-global yearabbr 18
-global yyyymm 201806
+global year 2019
+global yearabbr 19
+global yyyymm 201906
 
 /* -------------------
  ** ACS B01003
@@ -64,8 +64,8 @@ clear
  ** FCC FORM 477
  * ------------------- */
 
-/* JUNE 2018 */
-import delimited source/2018/fcc477/US-FIXED-JUN2018-v1, clear
+/* JUNE 2019 */
+import delimited source/2019/fcc477/US-FIXED-JUN2019-v2, clear
 
 // Drop states and territories outside 48 contiguous US states and DC
 drop if stateabbr == "AK" | stateabbr == "AS" | stateabbr == "GU" | stateabbr == "HI" | stateabbr == "MP" | stateabbr == "PR" | stateabbr == "VI"
@@ -80,11 +80,12 @@ drop if maxaddown < 25 | maxadup < 3
 drop dbaname holdingcompanyname hoconum hocofinal business maxcirdown maxcirup
 
 // Generate dates for panel
-generate month = date("06/30/2018", "MDY")
-generate year = date("2018", "Y")
+generate month = date("06/30/2019", "MDY")
+generate year = date("2019", "Y")
 
 // Clean formats to make variables consistent across 477 data files
 format maxaddown %9.0g
+format maxadup %9.0g
 
 /* FORMAT FCC FORM 477 DATA */
 // Change format of month and year
@@ -108,7 +109,7 @@ generate stateid = substr(blockid, 1, 2)
 
 
 /* -------------------
- ** PRODUCE FULL JUN 2018 FCC, ACS DATA 
+ ** PRODUCE FULL JUN 2019 FCC, ACS DATA 
  * ------------------- */
 
 /* MERGE ACS, BLOCK GROUP LANDAREA INTO FCC FORM 477 DATA */

--- a/scripts/crosssection-201912.do
+++ b/scripts/crosssection-201912.do
@@ -1,16 +1,16 @@
-/* Produce June 2018 dataset with
-** - ACS, block group landarea merged into June 2018 FCC Form 477 dataset,
+/* Produce December 2019 dataset with
+** - ACS, block group landarea merged into December 2019 FCC Form 477 dataset,
 ** - Housing and Population Density values, and
 ** - Competition metrics 
 **
 ** Outputs:
-** - crosssection/US-Fixed-Merged-201806.dta
-** - crosssection/merge-source-201806.log
-** - crosssection/merge-competition-vars-201806.log */
+** - crosssection/US-Fixed-Merged-201912.dta
+** - crosssection/merge-source-201912.log
+** - crosssection/merge-competition-vars-201912.log */
 
-global year 2018
-global yearabbr 18
-global yyyymm 201806
+global year 2019
+global yearabbr 19
+global yyyymm 201912
 
 /* -------------------
  ** ACS B01003
@@ -64,8 +64,8 @@ clear
  ** FCC FORM 477
  * ------------------- */
 
-/* JUNE 2018 */
-import delimited source/2018/fcc477/US-FIXED-JUN2018-v1, clear
+/* DECEMBER 2019 */
+import delimited source/2019/fcc477/US-FIXED-DEC2019-v1, clear
 
 // Drop states and territories outside 48 contiguous US states and DC
 drop if stateabbr == "AK" | stateabbr == "AS" | stateabbr == "GU" | stateabbr == "HI" | stateabbr == "MP" | stateabbr == "PR" | stateabbr == "VI"
@@ -77,11 +77,13 @@ keep if consumer == 1
 drop if maxaddown < 25 | maxadup < 3
 
 // Drop columns not needed for analysis
-drop dbaname holdingcompanyname hoconum hocofinal business maxcirdown maxcirup
+// Note: Dec 2019 v. 1 release does not include maxcirup or maxcirdown columns
+//       like previous releases, but business speeds are not considered in this analysis
+drop dbaname holdingcompanyname hoconum hocofinal business
 
 // Generate dates for panel
-generate month = date("06/30/2018", "MDY")
-generate year = date("2018", "Y")
+generate month = date("12/31/2019", "MDY")
+generate year = date("2019", "Y")
 
 // Clean formats to make variables consistent across 477 data files
 format maxaddown %9.0g
@@ -108,7 +110,7 @@ generate stateid = substr(blockid, 1, 2)
 
 
 /* -------------------
- ** PRODUCE FULL JUN 2018 FCC, ACS DATA 
+ ** PRODUCE FULL DEC 2019 FCC, ACS DATA 
  * ------------------- */
 
 /* MERGE ACS, BLOCK GROUP LANDAREA INTO FCC FORM 477 DATA */

--- a/scripts/helpers/b01003-compile.do
+++ b/scripts/helpers/b01003-compile.do
@@ -9,7 +9,7 @@ foreach state of global states {
 	format year %ty
 
 	// Format data
-	if $year == 2018 {
+	if $year == 2018 | $year == 2019 {
 		// Generate FIPS code for block groups
 		gen blkgrpid = substr(geo_id, 10, 12)
 		

--- a/scripts/helpers/b25001-compile.do
+++ b/scripts/helpers/b25001-compile.do
@@ -9,7 +9,7 @@ foreach state of global states {
 	format year %ty
 
 	// Format data
-	if $year == 2018 {
+	if $year == 2018 | $year == 2019 {
 		// Generate FIPS code for block groups
 		gen blkgrpid = substr(geo_id, 10, 12)
 		

--- a/scripts/helpers/competition-vars.do
+++ b/scripts/helpers/competition-vars.do
@@ -69,28 +69,40 @@ replace binary_aDSL1 = 1 if count_aDSL == 1
 gen binary_aDSL2 = 0
 replace binary_aDSL2 = 1 if count_aDSL == 2
 gen binary_aDSL3 = 0
-replace binary_aDSL3 = 1 if count_aDSL >= 3
+replace binary_aDSL3 = 1 if count_aDSL == 3
+gen binary_aDSL4 = 0
+replace binary_aDSL4 = 1 if count_aDSL == 4
 
 gen binary_cable1 = 0
 replace binary_cable1 = 1 if count_cable == 1
 gen binary_cable2 = 0
 replace binary_cable2 = 1 if count_cable == 2
 gen binary_cable3 = 0
-replace binary_cable3 = 1 if count_cable >= 3
+replace binary_cable3 = 1 if count_cable == 3
+gen binary_cable4 = 0
+replace binary_cable4 = 1 if count_cable == 4
+gen binary_cable5 = 0
+replace binary_cable5 = 1 if count_cable == 5
 
 gen binary_fiberGigabit1 = 0
 replace binary_fiberGigabit1 = 1 if count_fiberGigabit == 1
 gen binary_fiberGigabit2 = 0
 replace binary_fiberGigabit2 = 1 if count_fiberGigabit == 2
 gen binary_fiberGigabit3 = 0
-replace binary_fiberGigabit3 = 1 if count_fiberGigabit >= 3
+replace binary_fiberGigabit3 = 1 if count_fiberGigabit == 3
+gen binary_fiberGigabit4 = 0
+replace binary_fiberGigabit4 = 1 if count_fiberGigabit == 4
 
 gen binary_fiberNonGigabit1 = 0
 replace binary_fiberNonGigabit1 = 1 if count_fiberNonGigabit == 1
 gen binary_fiberNonGigabit2 = 0
 replace binary_fiberNonGigabit2 = 1 if count_fiberNonGigabit == 2
 gen binary_fiberNonGigabit3 = 0
-replace binary_fiberNonGigabit3 = 1 if count_fiberNonGigabit >= 3
+replace binary_fiberNonGigabit3 = 1 if count_fiberNonGigabit == 3
+gen binary_fiberNonGigabit4 = 0
+replace binary_fiberNonGigabit4 = 1 if count_fiberNonGigabit == 4
+gen binary_fiberNonGigabit5 = 0
+replace binary_fiberNonGigabit5 = 1 if count_fiberNonGigabit == 5
 
 // Produce binary indicating presence of any provider of given technology 
 gen binary_aDSL = 0

--- a/scripts/helpers/dataset-formatting.do
+++ b/scripts/helpers/dataset-formatting.do
@@ -6,11 +6,7 @@ order consumer, before(techcode)
 order blockid, before(blkgrpid)
 order stateabbr month year, after(stateid)
 order housing_density popln_density medianincome_tract_2018 medianincome_tract_moe_2018, before(totalpopulation_blkgrp)
-order count_aDSL binary_aDSL binary_aDSL1 binary_aDSL2 binary_aDSL3 count_cable binary_cable binary_cable1 binary_cable2 binary_cable3 count_fiber fiber_gigabit count_fiberGigabit binary_fiberGigabit binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 fiber_nongigabit count_fiberNonGigabit binary_fiberNonGigabit binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3, after(maxadup)
-
-
-/* DESCRIBE FULL DATASET */
-label data "FCC Form 477 Fixed Broadband Data, 2014-2018 from 25 percent of US Census Tracts"
+order count_aDSL binary_aDSL binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 count_cable binary_cable binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 count_fiber fiber_gigabit count_fiberGigabit binary_fiberGigabit binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 fiber_nongigabit count_fiberNonGigabit binary_fiberNonGigabit binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5, after(maxadup)
 
 /* LABEL VARIABLES AND VALUES, WHERE APPLICABLE */
 label variable logrecno "Logical record number relating broadband deployment tables to Imputations Table"
@@ -46,9 +42,13 @@ label variable binary_aDSL2 "Two aDSL providers in block"
 label define binary_aDSL2_vals 0 "No" 1 "Yes"
 label values binary_aDSL2 binary_aDSL2_vals
 
-label variable binary_aDSL3 "Three or more aDSL providers in block"
+label variable binary_aDSL3 "Three aDSL providers in block"
 label define binary_aDSL3_vals 0 "No" 1 "Yes"
 label values binary_aDSL3 binary_aDSL3_vals
+
+label variable binary_aDSL4 "Four aDSL providers in block"
+label define binary_aDSL4_vals 0 "No" 1 "Yes"
+label values binary_aDSL4 binary_aDSL4_vals
 
 label variable binary_cable "Cable provider (one or more) in block"
 label define binary_cable_vals 0 "No" 1 "Yes"
@@ -62,9 +62,17 @@ label variable binary_cable2 "Two cable providers in block"
 label define binary_cable2_vals 0 "No" 1 "Yes"
 label values binary_cable2 binary_cable2_vals
 
-label variable binary_cable3 "Three or more cable providers in block"
+label variable binary_cable3 "Three cable providers in block"
 label define binary_cable3_vals 0 "No" 1 "Yes"
 label values binary_cable3 binary_cable3_vals
+
+label variable binary_cable4 "Four cable providers in block"
+label define binary_cable4_vals 0 "No" 1 "Yes"
+label values binary_cable4 binary_cable4_vals
+
+label variable binary_cable5 "Five cable providers in block"
+label define binary_cable5_vals 0 "No" 1 "Yes"
+label values binary_cable5 binary_cable5_vals
 
 label variable binary_fiberGigabit "Fiber Gb provider (one or more) in block"
 label define binary_fiberGigabit_vals 0 "No" 1 "Yes"
@@ -78,9 +86,13 @@ label variable binary_fiberGigabit2 "Two fiber Gb providers in block"
 label define binary_fiberGigabit2_vals 0 "No" 1 "Yes"
 label values binary_fiberGigabit2 binary_fiberGigabit2_vals
 
-label variable binary_fiberGigabit3 "Three or more fiber Gb providers in block"
+label variable binary_fiberGigabit3 "Three fiber Gb providers in block"
 label define binary_fiberGigabit3_vals 0 "No" 1 "Yes"
 label values binary_fiberGigabit3 binary_fiberGigabit3_vals
+
+label variable binary_fiberGigabit4 "Four fiber Gb providers in block"
+label define binary_fiberGigabit4_vals 0 "No" 1 "Yes"
+label values binary_fiberGigabit4 binary_fiberGigabit4_vals
 
 label variable binary_fiberNonGigabit "Fiber ltGb provider (one or more) in block"
 label define binary_fiberNonGigabit_vals 0 "No" 1 "Yes"
@@ -94,9 +106,17 @@ label variable binary_fiberNonGigabit2 "Two fiber ltGb providers in block"
 label define binary_fiberNonGigabit2_vals 0 "No" 1 "Yes"
 label values binary_fiberNonGigabit2 binary_fiberNonGigabit2_vals
 
-label variable binary_fiberNonGigabit3 "Three or more fiber ltGb providers in block"
+label variable binary_fiberNonGigabit3 "Three fiber ltGb providers in block"
 label define binary_fiberNonGigabit3_vals 0 "No" 1 "Yes"
 label values binary_fiberNonGigabit3 binary_fiberNonGigabit3_vals
+
+label variable binary_fiberNonGigabit4 "Four fiber ltGb providers in block"
+label define binary_fiberNonGigabit4_vals 0 "No" 1 "Yes"
+label values binary_fiberNonGigabit4 binary_fiberNonGigabit4_vals
+
+label variable binary_fiberNonGigabit5 "Five fiber ltGb providers in block"
+label define binary_fiberNonGigabit5_vals 0 "No" 1 "Yes"
+label values binary_fiberNonGigabit5 binary_fiberNonGigabit5_vals
 
 label variable fiber_gigabit "Fiber gigabit service"
 label define fiber_gigabit_vals 0 "No" 1 "Yes"

--- a/scripts/helpers/dataset-formatting.do
+++ b/scripts/helpers/dataset-formatting.do
@@ -5,7 +5,7 @@ sort blockid month frn techcode
 order consumer, before(techcode)
 order blockid, before(blkgrpid)
 order stateabbr month year, after(stateid)
-order housing_density popln_density medianincome_tract_2018 medianincome_tract_moe_2018, before(totalpopulation_blkgrp)
+order housing_density popln_density medianincome_tract_2019 medianincome_tract_moe_2019, before(totalpopulation_blkgrp)
 order count_aDSL binary_aDSL binary_aDSL1 binary_aDSL2 binary_aDSL3 binary_aDSL4 count_cable binary_cable binary_cable1 binary_cable2 binary_cable3 binary_cable4 binary_cable5 count_fiber fiber_gigabit count_fiberGigabit binary_fiberGigabit binary_fiberGigabit1 binary_fiberGigabit2 binary_fiberGigabit3 binary_fiberGigabit4 fiber_nongigabit count_fiberNonGigabit binary_fiberNonGigabit binary_fiberNonGigabit1 binary_fiberNonGigabit2 binary_fiberNonGigabit3 binary_fiberNonGigabit4 binary_fiberNonGigabit5, after(maxadup)
 
 /* LABEL VARIABLES AND VALUES, WHERE APPLICABLE */
@@ -136,8 +136,8 @@ label variable month "Month"
 label variable year "Year"
 label variable housing_density "Housing Density"
 label variable popln_density "Population Density"
-label variable medianincome_tract_2018 "Median Income"
-label variable medianincome_tract_moe_2018 "Median Income - Margin of Error"
+label variable medianincome_tract_2019 "Median Income"
+label variable medianincome_tract_moe_2019 "Median Income - Margin of Error"
 label variable totalpopulation_blkgrp "Total Population"
 label variable totalpopulation_blkgrp_moe "Total Population - Margin of Error"
 label variable housingunits_blkgrp "Housing Units"

--- a/scripts/helpers/s1903-compile.do
+++ b/scripts/helpers/s1903-compile.do
@@ -1,4 +1,4 @@
-/* IMPORT, CLEAN, AND ADJUST MEDIAN INCOME DATA TO 2018 USD */
+/* IMPORT, CLEAN, AND ADJUST MEDIAN INCOME DATA TO 2019 USD */
 import delimited source/${year}/acs/s1903/ACS_${yearabbr}_5YR_S1903_with_ann, varnames(1) clear
 
 /* FORMAT ACS S1903 DATA */
@@ -8,7 +8,7 @@ replace year = yofd(year)
 format year %ty
 
 // Set column names
-if $year == 2018 {
+if $year == 2018 | $year == 2019 {
 	gen tractid = substr(geo_id, 10, 11)
 	rename s1903_c03_001e medianincome_tract
 	rename s1903_c03_001m medianincome_tract_moe
@@ -37,16 +37,17 @@ gen tractid_len = strlen(tractid)
 replace tractid = "0"+tractid if tractid_len == 10
 drop tractid_len
 
-if $year == 2018 {
-	rename medianincome_tract medianincome_tract_2018
-	rename medianincome_tract_moe medianincome_tract_moe_2018
+if $year == 2019 {
+	rename medianincome_tract medianincome_tract_2019
+	rename medianincome_tract_moe medianincome_tract_moe_2019
 }
 else {
-	// Adjust non-2018 income and moe estimates to 2018 dollars
+	// Adjust non-2019 income and moe estimates to 2019 dollars
 	merge m:1 year using source/bls/CPIAUCSL, generate(_merge_cpi) keep(match master)
-	generate medianincome_tract_2018 = round(medianincome_tract * (cpi_2018/cpi))
-	generate medianincome_tract_moe_2018 = round(medianincome_tract_moe * (cpi_2018/cpi))
+	generate medianincome_tract_2019 = round(medianincome_tract * (cpi_2019/cpi))
+	generate medianincome_tract_moe_2019 = round(medianincome_tract_moe * (cpi_2019/cpi))
 
 	// Drop unadjusted income data, CPI values, and Stata-generated _merge
-	drop medianincome_tract medianincome_tract_moe cpi cpi_2018 _merge_cpi
+	drop medianincome_tract medianincome_tract_moe cpi cpi_2019 _merge_cpi
 }
+

--- a/scripts/shared-data.do
+++ b/scripts/shared-data.do
@@ -6,8 +6,8 @@
 
 
 /* -------------------
- ** CONSUMER PRICE INDEX, 2014-2018
- ** To adjust median income estimates to 2018 dollars
+ ** CONSUMER PRICE INDEX, 2014-2019
+ ** To adjust median income estimates to 2019 dollars
  * ------------------- */
 
 import delimited source/bls/CPIAUCSL, clear
@@ -16,8 +16,8 @@ import delimited source/bls/CPIAUCSL, clear
 recast float year
 format year %ty
 
-// Produce column with 2018 CPI for inflation-adjustment calculation
-egen cpi_2018 = max(cond(year == 2018, cpi, .))
+// Produce column with 2019 CPI for inflation-adjustment calculation
+egen cpi_2019 = max(cond(year == 2019, cpi, .))
 
 save source/bls/CPIAUCSL, replace
 clear


### PR DESCRIPTION
The article has been accepted for publication at the _Journal of Information Policy_! Accordingly, I merge revisions to the Stata scripts that compile the dataset and execute the econometric tests as requested by the editor and reviewers. 

The headline change is that I've expanded the dataset to include FCC Form 477 data from **all Census blocks** in the 48 contiguous states and Washington, DC. In addition, I have extended the panel an additional year using the June and December 2019 releases of Form 477, as well as 2019 American Community Survey data. 

Other changes are described in CHANGELOG in root.